### PR TITLE
Simplest healthcheck without heavy rework

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,36 +1,39 @@
 #!/usr/bin/env bash
 
 set -eax
+# Put last healthcheck logs in an file (You might persist this for healthcheck failures analysis as the container is ephemeral)
+# Otherwise healthcheck logs are found in docker inspect <container_id>
+
+exec > /tmp/healthcheck.log 2>&1
 
 if [ "$SERVICE_MODE" = "http" ]
 then
+    # HTTP mode healthcheck
     curl --fail http://localhost:80/healthcheck || exit 1
 else
     # Update last alive
     python -c "from celery_app.register import register; register(False)"
 
     # Check if Celery worker process is running
-    # warning : We might rework this when switching to non-root user. Which is required for security reasons.
-    # Our docker images are currently running as root and this is bad :)
     PID=`pgrep -f "celeryapp worker"`
     if [ -z "$PID" ]; then
-        echo "HealtchCheck FAIL : Celery worker process not running"
+        echo "HealthCheck FAIL: Celery worker process not running"
         exit 1
     fi
 
-    # Check if GPU is in used
-    has_gpu=$(nvidia-smi --query-compute-apps pid --format=csv,noheader | wc -l)
-    # Note: we should add a check on the PID ("| grep $PID")... BUT the PID can be different in the container than on the host
+    # Check if GPU is in use
+    has_gpu=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | grep -v '^0$')
+    if [ "$has_gpu" -gt 0 ]; then
+        echo "HealthCheck PASS: GPU is being utilized, marking service as healthy."
+        exit 0
+    fi
 
-    # Attempt a ping
+    # Attempt to ping Celery worker
     if ! celery --app=celery_app.celeryapp inspect ping -d ${SERVICE_NAME}_worker@$HOSTNAME --timeout=20; then
-        # Check GPU utilization
-        if [ $has_gpu -gt 0 ]; then
-            # GPU is being utilized, assuming healthy
-            echo "Celery worker not responding in time but GPU is being utilized (trying to ping again)"
-            exit 0
-        fi
-        echo "HealtchCheck FAIL : Celery worker not responding in time and GPU is not being utilized"
+        echo "HealthCheck FAIL: Celery worker not responding in time and GPU is not being utilized"
         exit 1
     fi
+
+    echo "HealthCheck PASS: Celery worker is responsive but idle, marking service as healthy."
+    exit 0
 fi

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 set -eax
+
 # Put last healthcheck logs in an file (You might persist this for healthcheck failures analysis as the container is ephemeral)
 # Otherwise healthcheck logs are found in docker inspect <container_id>
-
 exec > /tmp/healthcheck.log 2>&1
 
 if [ "$SERVICE_MODE" = "http" ]


### PR DESCRIPTION
# Pull Request: Simplified Healthcheck for Diarization Celery Worker

This PR introduces a simplified healthcheck approach for the diarization Celery worker by assessing GPU usage at a global level and verifying the Celery task PID status to determine the health status.

## Reasoning

### Solo Pool & Thread Safety
The diarization worker uses Celery’s solo pool to avoid Python’s thread-related issues with GPU operations. In Python, multi-threaded access to GPUs can lead to contention or memory conflicts. Using the solo pool ensures only one task runs at a time, mitigating these issues.

### Container Namespace & Non-Root Constraints
We avoid using methods like:

```bash
HOST_PID=$(docker inspect -f '{{.State.Pid}}' <container_id>)
nsenter --target $HOST_PID --pid -- bash -c ...
```

While these methods theoretically allow tracking the current task’s GPU usage, they require elevated privileges or `--pid=host` mode, which present security risks. Additionally, these methods restrict non-root configurations, reducing container security.

### Limitations with Celery’s Inspect Commands
Using Celery’s `inspect active`, `inspect reserved`, and `inspect ping` to check task statuses has limitations:

```bash
active_tasks=$(celery --app=celery_app.celeryapp inspect active ...)
reserved_tasks=$(celery --app=celery_app.celeryapp inspect reserved ...)
```

When the worker is busy, these commands fail or yield inconsistent results because Celery struggles with handling inspection commands while actively processing tasks. This inconsistency makes these checks unreliable for health monitoring.

## Current Solution
The current approach assumes that if the worker’s PID is active and the GPU usage is non-zero, the service is operational. This simplifies the healthcheck with a fair reliability.

## Potential Improvements

### Mitigate Desyncs

We occasionally encounter warnings in the logs about "substantial drift," indicating a potential desynchronization between workers. An example of such a log entry is:

```bash
linto_stt-diarization-pyannote.1.rcitcuqahk29@docker-desktop | [2024-10-28 20:41:04,722: WARNING/MainProcess] Substantial drift from stt-french-whisper-v3_request_worker@84ac237a12af may mean clocks are out of sync. Current drift is 1101 seconds. [orig: 2024-10-28 20:41:04.722422 recv: 2024-10-28 20:22:43.918819]
linto_stt-diarization-pyannote.1.rcitcuqahk29@docker-desktop | [2024-10-28 20:41:04,723: WARNING/MainProcess] Substantial drift from stt-french-whisper-v3_worker@2d4d8966539a may mean clocks are out of sync. Current drift is 1100 seconds. [orig: 2024-10-28 20:41:04.722949 recv: 2024-10-28 20:22:44.102505]
```

This "substantial drift" warning suggests that something is kind of fishy with Celery’s internal heartbeats or task timing, when the worker is busy. This may be challenging to resolve without adjusting Celery’s concurrency settings and switching to a different pool type.


### Switching to Eventlet
Transitioning to an Eventlet pool for better concurrency, especially if the task implementation shifts to async-compatible methods (e.g., `.delay()`).

### Implementing GPU Locking with Celery Signals
Using Celery signals to set up a semaphore or lock around GPU tasks can ensure safe access. Here’s a potential implementation:

```python
from celery import signals

@signals.task_prerun.connect
def acquire_gpu_lock(sender, **kwargs):
    # Code to acquire a GPU lock

@signals.task_postrun.connect
def release_gpu_lock(sender, **kwargs):
    # Code to release the GPU lock
```

This would prevent GPU contention and ensure that only one task accesses the GPU at a time.